### PR TITLE
Add `ZeroExApiAdapter`

### DIFF
--- a/contracts/mocks/external/ZeroExMock.sol
+++ b/contracts/mocks/external/ZeroExMock.sol
@@ -1,0 +1,66 @@
+/*
+    Copyright 2020 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
+
+// Minimal 0x Exchange Proxy contract interface.
+contract ZeroExMock {
+
+    struct Transformation {
+        uint32 deploymentNonce;
+        bytes data;
+    }
+
+    function transformERC20(
+        address /* inputToken */,
+        address /* outputToken */,
+        uint256 /* inputTokenAmount */,
+        uint256 /* minOutputTokenAmount */,
+        Transformation[] calldata /* transformations */
+    )
+        external
+        payable
+        returns (uint256 outputTokenAmount)
+    { }
+
+    function sellToUniswap(
+        address[] calldata /* tokens */,
+        uint256 /* sellAmount */,
+        uint256 /* minBuyAmount */,
+        bool /* isSushi */
+    )
+        external
+        payable
+        returns (uint256 buyAmount)
+    { }
+
+    function sellToLiquidityProvider(
+        address /* inputToken */,
+        address /* outputToken */,
+        address payable /* provider */,
+        address /* recipient */,
+        uint256 /* sellAmount */,
+        uint256 /* minBuyAmount */,
+        bytes calldata /* auxiliaryData */
+    )
+        external
+        payable
+        returns (uint256 boughtAmount)
+    { }
+}

--- a/contracts/mocks/external/ZeroExMock.sol
+++ b/contracts/mocks/external/ZeroExMock.sol
@@ -19,12 +19,38 @@
 pragma solidity 0.6.10;
 pragma experimental ABIEncoderV2;
 
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
 // Minimal 0x Exchange Proxy contract interface.
 contract ZeroExMock {
 
     struct Transformation {
         uint32 deploymentNonce;
         bytes data;
+    }
+
+    address public mockReceiveToken;
+    address public mockSendToken;
+    uint256 public mockReceiveAmount;
+    uint256 public mockSendAmount;
+    // Address of SetToken which will send/receive token
+    address public setTokenAddress;
+
+    constructor(
+        address _mockSendToken,
+        address _mockReceiveToken,
+        uint256 _mockSendAmount,
+        uint256 _mockReceiveAmount
+    ) public {
+        mockSendToken = _mockSendToken;
+        mockReceiveToken = _mockReceiveToken;
+        mockSendAmount = _mockSendAmount;
+        mockReceiveAmount = _mockReceiveAmount;
+    }
+
+    // Initialize SetToken address which will send/receive tokens for the trade
+    function addSetTokenAddress(address _setTokenAddress) external {
+        setTokenAddress = _setTokenAddress;
     }
 
     function transformERC20(
@@ -36,8 +62,11 @@ contract ZeroExMock {
     )
         external
         payable
-        returns (uint256 outputTokenAmount)
-    { }
+        returns (uint256)
+    {
+        require(ERC20(mockSendToken).transferFrom(setTokenAddress, address(this), mockSendAmount), "ERC20 TransferFrom failed");
+        require(ERC20(mockReceiveToken).transfer(setTokenAddress, mockReceiveAmount), "ERC20 transfer failed");
+    }
 
     function sellToUniswap(
         address[] calldata /* tokens */,
@@ -47,8 +76,11 @@ contract ZeroExMock {
     )
         external
         payable
-        returns (uint256 buyAmount)
-    { }
+        returns (uint256)
+    {
+        require(ERC20(mockSendToken).transferFrom(setTokenAddress, address(this), mockSendAmount), "ERC20 TransferFrom failed");
+        require(ERC20(mockReceiveToken).transfer(setTokenAddress, mockReceiveAmount), "ERC20 transfer failed");
+    }
 
     function sellToLiquidityProvider(
         address /* inputToken */,
@@ -61,6 +93,9 @@ contract ZeroExMock {
     )
         external
         payable
-        returns (uint256 boughtAmount)
-    { }
+        returns (uint256)
+    {
+        require(ERC20(mockSendToken).transferFrom(setTokenAddress, address(this), mockSendAmount), "ERC20 TransferFrom failed");
+        require(ERC20(mockReceiveToken).transfer(setTokenAddress, mockReceiveAmount), "ERC20 transfer failed");
+    }
 }

--- a/contracts/protocol/integration/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/ZeroExApiAdapter.sol
@@ -51,6 +51,7 @@ contract ZeroExApiAdapter {
      *
      * @param  _sourceToken              Address of source token to be sold
      * @param  _destinationToken         Address of destination token to buy
+     * @param  _destinationAddress       Address that assets should be transferred to
      * @param  _sourceQuantity           Amount of source token to sell
      * @param  _minDestinationQuantity   Min amount of destination token to buy
      * @param  _data                     Arbitrage bytes containing trade call data

--- a/contracts/protocol/integration/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/ZeroExApiAdapter.sol
@@ -30,6 +30,9 @@ contract ZeroExApiAdapter {
 
     /* ============ State Variables ============ */
 
+    // ETH pseudo-token address used by 0x API.
+    address private constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
     // Address of the deployed ZeroEx contract.
     address public immutable zeroExAddress;
 
@@ -121,7 +124,8 @@ contract ZeroExApiAdapter {
 
         return (
             zeroExAddress,
-            0, // callValue cannot be determined from calldata.
+            // Note: Does not account for limit order protocol fees.
+            inputToken == ETH_ADDRESS ? inputTokenAmount : 0,
             _data
         );
     }

--- a/contracts/protocol/integration/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/ZeroExApiAdapter.sol
@@ -66,7 +66,7 @@ contract ZeroExApiAdapter {
         address _destinationAddress,
         uint256 _sourceQuantity,
         uint256 _minDestinationQuantity,
-        bytes memory _data
+        bytes calldata _data
     )
         external
         view
@@ -80,38 +80,37 @@ contract ZeroExApiAdapter {
         uint256 inputTokenAmount;
         uint256 minOutputTokenAmount;
 
+        {
+            require(_data.length >= 4, "Invalid calldata");
+            bytes4 selector;
+            assembly {
+                selector := and(
+                    // Read the first 4 bytes of the _data array from calldata.
+                    calldataload(add(36, calldataload(164))), // 164 = 5 * 32 + 4
+                    0xffffffff00000000000000000000000000000000000000000000000000000000
+                )
+            }
 
-        bytes4 selector;
-        require(_data.length >= 4, "Invalid calldata");
-        assembly {
-            selector := and(
-                mload(add(_data, 32)),
-                0xffffffff00000000000000000000000000000000000000000000000000000000
-            )
-            // Chop off the first 4 bytes of the _data byte array
-            mstore(add(_data, 4), sub(mload(_data), 4))
-            _data := add(_data, 4)
-        }
-
-        if (selector == 0x415565b0) {
-            // transformERC20()
-            (inputToken, outputToken, inputTokenAmount, minOutputTokenAmount) =
-                abi.decode(_data, (address, address, uint256, uint256));
-        } else if (selector == 0xf7fcd384) {
-            // sellToLiquidityProvider()
-            (inputToken, outputToken, , recipient, inputTokenAmount, minOutputTokenAmount) =
-                abi.decode(_data, (address, address, address, address, uint256, uint256));
-            supportsRecipient = true;
-        } else if (selector == 0xd9627aa4) {
-            // sellToUniswap()
-            address[] memory path;
-            (path, inputTokenAmount, minOutputTokenAmount) =
-                abi.decode(_data, (address[], uint256, uint256));
-            require(path.length > 1, "Uniswap token path too short");
-            inputToken = path[0];
-            outputToken = path[path.length - 1];
-        } else {
-            revert("Unsupported 0xAPI function selector");
+            if (selector == 0x415565b0) {
+                // transformERC20()
+                (inputToken, outputToken, inputTokenAmount, minOutputTokenAmount) =
+                    abi.decode(_data[4:], (address, address, uint256, uint256));
+            } else if (selector == 0xf7fcd384) {
+                // sellToLiquidityProvider()
+                (inputToken, outputToken, , recipient, inputTokenAmount, minOutputTokenAmount) =
+                    abi.decode(_data[4:], (address, address, address, address, uint256, uint256));
+                supportsRecipient = true;
+            } else if (selector == 0xd9627aa4) {
+                // sellToUniswap()
+                address[] memory path;
+                (path, inputTokenAmount, minOutputTokenAmount) =
+                    abi.decode(_data[4:], (address[], uint256, uint256));
+                require(path.length > 1, "Uniswap token path too short");
+                inputToken = path[0];
+                outputToken = path[path.length - 1];
+            } else {
+                revert("Unsupported 0xAPI function selector");
+            }
         }
 
         require(inputToken == _sourceToken, "Mismatched input token");
@@ -119,14 +118,6 @@ contract ZeroExApiAdapter {
         require(!supportsRecipient || recipient == _destinationAddress, "Mismatched recipient");
         require(inputTokenAmount == _sourceQuantity, "Mismatched input token quantity");
         require(minOutputTokenAmount >= _minDestinationQuantity, "Mismatched output token quantity");
-
-        // Prepend the original first 4 bytes to the _data byte array
-        assembly {
-            let len := add(mload(_data), 4)
-            mstore(_data, shr(224, selector))
-            _data := sub(_data, 4)
-            mstore(_data, len)
-        }
 
         return (
             zeroExAddress,

--- a/contracts/protocol/integration/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/ZeroExApiAdapter.sol
@@ -1,0 +1,136 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+pragma experimental "ABIEncoderV2";
+
+/**
+ * @title ZeroExApiAdapter
+ * @author Set Protocol
+ *
+ * Exchange adapter for 0xAPI that returns data for swaps
+ */
+
+contract ZeroExApiAdapter {
+
+    /* ============ State Variables ============ */
+
+    // Address of the deployed ZeroEx contract.
+    address public immutable zeroExAddress;
+
+    // Returns the address to approve source tokens to for trading. This is the TokenTaker address
+    address public immutable getSpender;
+
+    /* ============ constructor ============ */
+
+    constructor(address _zeroExAddress) public {
+        zeroExAddress = _zeroExAddress;
+        getSpender = _zeroExAddress;
+    }
+
+
+    /* ============ External Getter Functions ============ */
+
+    /**
+     * Return 0xAPI calldata which is already generated from 0xAPI
+     *
+     * @param  _sourceToken              Address of source token to be sold
+     * @param  _destinationToken         Address of destination token to buy
+     * @param  _sourceQuantity           Amount of source token to sell
+     * @param  _minDestinationQuantity   Min amount of destination token to buy
+     * @param  _data                     Arbitrage bytes containing trade call data
+     *
+     * @return address                   Target contract address
+     * @return uint256                   Call value
+     * @return bytes                     Trade calldata
+     */
+    function getTradeCalldata(
+        address _sourceToken,
+        address _destinationToken,
+        address _destinationAddress,
+        uint256 _sourceQuantity,
+        uint256 _minDestinationQuantity,
+        bytes memory _data
+    )
+        external
+        view
+        returns (address, uint256, bytes memory)
+    {
+        // solium-disable security/no-inline-assembly
+        address inputToken;
+        address outputToken;
+        address recipient;
+        bool supportsRecipient;
+        uint256 inputTokenAmount;
+        uint256 minOutputTokenAmount;
+
+
+        bytes4 selector;
+        require(_data.length >= 4, "Invalid calldata");
+        assembly {
+            selector := and(
+                mload(add(_data, 32)),
+                0xffffffff00000000000000000000000000000000000000000000000000000000
+            )
+            // Chop off the first 4 bytes of the _data byte array
+            mstore(add(_data, 4), sub(mload(_data), 4))
+            _data := add(_data, 4)
+        }
+
+        if (selector == 0x415565b0) {
+            // transformERC20()
+            (inputToken, outputToken, inputTokenAmount, minOutputTokenAmount) =
+                abi.decode(_data, (address, address, uint256, uint256));
+        } else if (selector == 0xf7fcd384) {
+            // sellToLiquidityProvider()
+            (inputToken, outputToken, , recipient, inputTokenAmount, minOutputTokenAmount) =
+                abi.decode(_data, (address, address, address, address, uint256, uint256));
+            supportsRecipient = true;
+        } else if (selector == 0xd9627aa4) {
+            // sellToUniswap()
+            address[] memory path;
+            (path, inputTokenAmount, minOutputTokenAmount) =
+                abi.decode(_data, (address[], uint256, uint256));
+            require(path.length > 1, "Uniswap token path too short");
+            inputToken = path[0];
+            outputToken = path[path.length - 1];
+        } else {
+            revert("Unsupported 0xAPI function selector");
+        }
+
+        require(inputToken == _sourceToken, "Mismatched input token");
+        require(outputToken == _destinationToken, "Mismatched output token");
+        require(!supportsRecipient || recipient == _destinationAddress, "Mismatched recipient");
+        require(inputTokenAmount == _sourceQuantity, "Mismatched input token quantity");
+        require(minOutputTokenAmount >= _minDestinationQuantity, "Mismatched output token quantity");
+
+        // Prepend the original first 4 bytes to the _data byte array
+        assembly {
+            let len := add(mload(_data), 4)
+            mstore(_data, shr(224, selector))
+            _data := sub(_data, 4)
+            mstore(_data, len)
+        }
+
+        return (
+            zeroExAddress,
+            0, // callValue cannot be determined from calldata.
+            _data
+        );
+    }
+}

--- a/test/protocol/integration/zeroExApiAdapter.spec.ts
+++ b/test/protocol/integration/zeroExApiAdapter.spec.ts
@@ -1,0 +1,381 @@
+import "module-alias/register";
+
+import { Account } from "@utils/test/types";
+import { ADDRESS_ZERO, ONE, ZERO, EMPTY_BYTES } from "@utils/constants";
+import { ZeroExApiAdapter, ZeroExMock } from "@utils/contracts";
+import DeployHelper from "@utils/deploys";
+import { addSnapshotBeforeRestoreAfterEach, getAccounts, getWaffleExpect } from "@utils/test/index";
+
+const expect = getWaffleExpect();
+
+describe("ZeroExApiAdapter", () => {
+  let owner: Account;
+  const sourceToken = "0x6cf5f1d59fddae3a688210953a512b6aee6ea643";
+  const destToken = "0x5e5d0bea9d4a15db2d0837aff0435faba166190d";
+  const otherToken = "0xae9902bb655de1a67f334d8661b3ae6a96723d5b";
+  const destination = "0x89b3515cad4f23c1deacea79fc12445cc21bd0e1";
+  const otherDestination = "0xdeb100c55cccfd6e39753f78c8b0c3bcbef86157";
+  const sourceQuantity = ONE;
+  const minDestinationQuantity = ONE.mul(2);
+  const otherQuantity = ONE.div(2);
+  let deployer: DeployHelper;
+
+  let zeroExMock: ZeroExMock;
+  let zeroExApiAdapter: ZeroExApiAdapter;
+
+  before(async () => {
+    [owner] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    // Mock OneInch exchange that allows for only fixed exchange amounts
+    zeroExMock = await deployer.mocks.deployZeroExMock();
+    zeroExApiAdapter = await deployer.adapters.deployZeroExApiAdapter(zeroExMock.address);
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("getTradeCalldata", () => {
+    it("rejects unsupported function", async () => {
+      const data = zeroExMock.interface.encodeFunctionData("transformERC20", [
+        sourceToken,
+        destToken,
+        sourceQuantity,
+        minDestinationQuantity,
+        [],
+      ]);
+      const tx = zeroExApiAdapter.getTradeCalldata(
+        sourceToken,
+        destToken,
+        destination,
+        sourceQuantity,
+        minDestinationQuantity,
+        "0x01234567" + data.slice(10),
+      );
+      await expect(tx).to.be.revertedWith("Unsupported 0xAPI function selector");
+    });
+
+    describe("transformERC20", () => {
+      it("validates data", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("transformERC20", [
+          sourceToken,
+          destToken,
+          sourceQuantity,
+          minDestinationQuantity,
+          [],
+        ]);
+        const [target, value, _data] = await zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        expect(target).to.eq(zeroExMock.address);
+        expect(value).to.deep.eq(ZERO);
+        expect(_data).to.deep.eq(data);
+      });
+
+      it("rejects wrong input token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("transformERC20", [
+          otherToken,
+          destToken,
+          sourceQuantity,
+          minDestinationQuantity,
+          [],
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token");
+      });
+
+      it("rejects wrong output token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("transformERC20", [
+          sourceToken,
+          otherToken,
+          sourceQuantity,
+          minDestinationQuantity,
+          [],
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token");
+      });
+
+      it("rejects wrong input token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("transformERC20", [
+          sourceToken,
+          destToken,
+          otherQuantity,
+          minDestinationQuantity,
+          [],
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token quantity");
+      });
+
+      it("rejects wrong output token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("transformERC20", [
+          sourceToken,
+          destToken,
+          sourceQuantity,
+          otherQuantity,
+          [],
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token quantity");
+      });
+    });
+
+    describe("sellToUniswap", () => {
+      it("validates data", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToUniswap", [
+          [sourceToken, destToken],
+          sourceQuantity,
+          minDestinationQuantity,
+          false,
+        ]);
+        const [target, value, _data] = await zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        expect(target).to.eq(zeroExMock.address);
+        expect(value).to.deep.eq(ZERO);
+        expect(_data).to.deep.eq(data);
+      });
+
+      it("rejects wrong input token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToUniswap", [
+          [otherToken, destToken],
+          sourceQuantity,
+          minDestinationQuantity,
+          false,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token");
+      });
+
+      it("rejects wrong output token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToUniswap", [
+          [sourceToken, otherToken],
+          sourceQuantity,
+          minDestinationQuantity,
+          false,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token");
+      });
+
+      it("rejects wrong input token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToUniswap", [
+          [sourceToken, destToken],
+          otherQuantity,
+          minDestinationQuantity,
+          false,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token quantity");
+      });
+
+      it("rejects wrong output token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToUniswap", [
+          [sourceToken, destToken],
+          sourceQuantity,
+          otherQuantity,
+          false,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token quantity");
+      });
+    });
+
+    describe("sellToLiquidityProvider", () => {
+      it("validates data", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToLiquidityProvider", [
+          sourceToken,
+          destToken,
+          ADDRESS_ZERO,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          EMPTY_BYTES,
+        ]);
+        const [target, value, _data] = await zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        expect(target).to.eq(zeroExMock.address);
+        expect(value).to.deep.eq(ZERO);
+        expect(_data).to.deep.eq(data);
+      });
+
+      it("rejects wrong input token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToLiquidityProvider", [
+          otherToken,
+          destToken,
+          ADDRESS_ZERO,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          EMPTY_BYTES,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token");
+      });
+
+      it("rejects wrong output token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToLiquidityProvider", [
+          sourceToken,
+          otherToken,
+          ADDRESS_ZERO,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          EMPTY_BYTES,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token");
+      });
+
+      it("rejects wrong input token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToLiquidityProvider", [
+          sourceToken,
+          destToken,
+          ADDRESS_ZERO,
+          destination,
+          otherQuantity,
+          minDestinationQuantity,
+          EMPTY_BYTES,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token quantity");
+      });
+
+      it("rejects wrong output token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToLiquidityProvider", [
+          sourceToken,
+          destToken,
+          ADDRESS_ZERO,
+          destination,
+          sourceQuantity,
+          otherQuantity,
+          EMPTY_BYTES,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token quantity");
+      });
+
+      it("rejects wrong destination", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("sellToLiquidityProvider", [
+          sourceToken,
+          destToken,
+          ADDRESS_ZERO,
+          otherDestination,
+          sourceQuantity,
+          otherQuantity,
+          EMPTY_BYTES,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched recipient");
+      });
+    });
+  });
+});

--- a/test/protocol/integration/zeroExApiAdapter.spec.ts
+++ b/test/protocol/integration/zeroExApiAdapter.spec.ts
@@ -29,7 +29,12 @@ describe("ZeroExApiAdapter", () => {
     deployer = new DeployHelper(owner.wallet);
 
     // Mock OneInch exchange that allows for only fixed exchange amounts
-    zeroExMock = await deployer.mocks.deployZeroExMock();
+    zeroExMock = await deployer.mocks.deployZeroExMock(
+        ADDRESS_ZERO,
+        ADDRESS_ZERO,
+        ZERO,
+        ZERO,
+    );
     zeroExApiAdapter = await deployer.adapters.deployZeroExApiAdapter(zeroExMock.address);
   });
 

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -64,3 +64,5 @@ export { UniswapYieldStrategy } from "../../typechain/UniswapYieldStrategy";
 export { WETH9 } from "../../typechain/WETH9";
 export { WrapAdapterMock } from "../../typechain/WrapAdapterMock";
 export { WrapModule } from "../../typechain/WrapModule";
+export { ZeroExApiAdapter } from "../../typechain/ZeroExApiAdapter";
+export { ZeroExMock } from "../../typechain/ZeroExMock";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -9,7 +9,8 @@ import {
   AaveMigrationWrapAdapter,
   AaveWrapAdapter,
   UniswapPairPriceAdapter,
-  UniswapV2ExchangeAdapter
+  UniswapV2ExchangeAdapter,
+  ZeroExApiAdapter,
 } from "../contracts";
 
 import { Address, Bytes } from "./../types";
@@ -19,6 +20,7 @@ import { CompoundLikeGovernanceAdapter__factory } from "../../typechain/factorie
 import { CurveStakingAdapter__factory } from "../../typechain/factories/CurveStakingAdapter__factory";
 import { KyberExchangeAdapter__factory } from "../../typechain/factories/KyberExchangeAdapter__factory";
 import { OneInchExchangeAdapter__factory } from "../../typechain/factories/OneInchExchangeAdapter__factory";
+import { ZeroExApiAdapter__factory } from "../../typechain/factories/ZeroExApiAdapter__factory";
 import { AaveMigrationWrapAdapter__factory } from "../../typechain/factories/AaveMigrationWrapAdapter__factory";
 import { AaveWrapAdapter__factory } from "../../typechain/factories/AaveWrapAdapter__factory";
 import { UniswapPairPriceAdapter__factory } from "../../typechain/factories/UniswapPairPriceAdapter__factory";
@@ -85,5 +87,9 @@ export default class DeployAdapters {
 
   public async getUniswapPairPriceAdapter(uniswapAdapterAddress: Address): Promise<UniswapPairPriceAdapter> {
     return await new UniswapPairPriceAdapter__factory(this._deployerSigner).attach(uniswapAdapterAddress);
+  }
+
+  public async deployZeroExApiAdapter(zeroExAddress: Address): Promise<ZeroExApiAdapter> {
+    return await new ZeroExApiAdapter__factory(this._deployerSigner).deploy(zeroExAddress);
   }
 }

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -31,6 +31,7 @@ import {
   StandardTokenWithFeeMock,
   Uint256ArrayUtilsMock,
   WrapAdapterMock,
+  ZeroExMock,
 } from "../contracts";
 
 import { ether } from "../common";
@@ -63,6 +64,7 @@ import { StandardTokenMock__factory } from "../../typechain/factories/StandardTo
 import { StandardTokenWithFeeMock__factory } from "../../typechain/factories/StandardTokenWithFeeMock__factory";
 import { Uint256ArrayUtilsMock__factory } from "../../typechain/factories/Uint256ArrayUtilsMock__factory";
 import { WrapAdapterMock__factory } from "../../typechain/factories/WrapAdapterMock__factory";
+import { ZeroExMock__factory } from "../../typechain/factories/ZeroExMock__factory";
 
 export default class DeployMocks {
   private _deployerSigner: Signer;
@@ -131,6 +133,10 @@ export default class DeployMocks {
       sendQuantity,
       receiveQuantity,
     );
+  }
+
+  public async deployZeroExMock(): Promise<ZeroExMock> {
+    return await new ZeroExMock__factory(this._deployerSigner).deploy();
   }
 
   public async deployOracleMock(initialValue: BigNumberish): Promise<OracleMock> {

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -135,8 +135,18 @@ export default class DeployMocks {
     );
   }
 
-  public async deployZeroExMock(): Promise<ZeroExMock> {
-    return await new ZeroExMock__factory(this._deployerSigner).deploy();
+  public async deployZeroExMock(
+    sendToken: Address,
+    receiveToken: Address,
+    sendQuantity: BigNumber,
+    receiveQuantity: BigNumber,
+  ): Promise<ZeroExMock> {
+    return await new ZeroExMock__factory(this._deployerSigner).deploy(
+        sendToken,
+        receiveToken,
+        sendQuantity,
+        receiveQuantity,
+    );
   }
 
   public async deployOracleMock(initialValue: BigNumberish): Promise<OracleMock> {


### PR DESCRIPTION
:wave: 

Adds an adapter (`ZeroExApiAdapter`) that validates calldata returned by the 0x API. Note: the call value returned by the `getTradeCalldata()` function will always be zero, as it's a bit tricky to figure out how much value should be attached from the calldata. Is it OK to trust the `value` returned by API for now?