### PR TITLE
add `batchFill()` and `multiHopFill()` support to ZeroExApiAdapter

### DIFF
--- a/contracts/mocks/external/ZeroExMock.sol
+++ b/contracts/mocks/external/ZeroExMock.sol
@@ -29,6 +29,30 @@ contract ZeroExMock {
         bytes data;
     }
 
+    struct BatchFillData {
+        address inputToken;
+        address outputToken;
+        uint256 sellAmount;
+        WrappedBatchCall[] calls;
+    }
+
+    struct WrappedBatchCall {
+        bytes4 selector;
+        uint256 sellAmount;
+        bytes data;
+    }
+
+    struct MultiHopFillData {
+        address[] tokens;
+        uint256 sellAmount;
+        WrappedMultiHopCall[] calls;
+    }
+
+    struct WrappedMultiHopCall {
+        bytes4 selector;
+        bytes data;
+    }
+
     address public mockReceiveToken;
     address public mockSendToken;
     uint256 public mockReceiveAmount;
@@ -64,8 +88,7 @@ contract ZeroExMock {
         payable
         returns (uint256)
     {
-        require(ERC20(mockSendToken).transferFrom(setTokenAddress, address(this), mockSendAmount), "ERC20 TransferFrom failed");
-        require(ERC20(mockReceiveToken).transfer(setTokenAddress, mockReceiveAmount), "ERC20 transfer failed");
+        _transferTokens();
     }
 
     function sellToUniswap(
@@ -78,8 +101,7 @@ contract ZeroExMock {
         payable
         returns (uint256)
     {
-        require(ERC20(mockSendToken).transferFrom(setTokenAddress, address(this), mockSendAmount), "ERC20 TransferFrom failed");
-        require(ERC20(mockReceiveToken).transfer(setTokenAddress, mockReceiveAmount), "ERC20 transfer failed");
+        _transferTokens();
     }
 
     function sellToLiquidityProvider(
@@ -94,6 +116,34 @@ contract ZeroExMock {
         external
         payable
         returns (uint256)
+    {
+        _transferTokens();
+    }
+
+    function batchFill(
+        BatchFillData memory /* fillData */,
+        uint256 /* minBuyAmount */
+    )
+        external
+        payable
+        returns (uint256)
+    {
+        _transferTokens();
+    }
+
+    function multiHopFill(
+        MultiHopFillData memory /* fillData */,
+        uint256 /* minBuyAmount */
+    )
+        external
+        payable
+        returns (uint256)
+    {
+        _transferTokens();
+    }
+
+    function _transferTokens()
+        private
     {
         require(ERC20(mockSendToken).transferFrom(setTokenAddress, address(this), mockSendAmount), "ERC20 TransferFrom failed");
         require(ERC20(mockReceiveToken).transfer(setTokenAddress, mockReceiveAmount), "ERC20 transfer failed");

--- a/contracts/protocol/integration/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/ZeroExApiAdapter.sol
@@ -28,6 +28,30 @@ pragma experimental "ABIEncoderV2";
 
 contract ZeroExApiAdapter {
 
+    struct BatchFillData {
+        address inputToken;
+        address outputToken;
+        uint256 sellAmount;
+        WrappedBatchCall[] calls;
+    }
+
+    struct WrappedBatchCall {
+        bytes4 selector;
+        uint256 sellAmount;
+        bytes data;
+    }
+
+    struct MultiHopFillData {
+        address[] tokens;
+        uint256 sellAmount;
+        WrappedMultiHopCall[] calls;
+    }
+
+    struct WrappedMultiHopCall {
+        bytes4 selector;
+        bytes data;
+    }
+
     /* ============ State Variables ============ */
 
     // ETH pseudo-token address used by 0x API.
@@ -45,7 +69,6 @@ contract ZeroExApiAdapter {
         zeroExAddress = _zeroExAddress;
         getSpender = _zeroExAddress;
     }
-
 
     /* ============ External Getter Functions ============ */
 
@@ -111,6 +134,23 @@ contract ZeroExApiAdapter {
                 require(path.length > 1, "Uniswap token path too short");
                 inputToken = path[0];
                 outputToken = path[path.length - 1];
+            } else if (selector == 0xafc6728e) {
+                // batchFill()
+                BatchFillData memory fillData;
+                (fillData, minOutputTokenAmount) =
+                    abi.decode(_data[4:], (BatchFillData, uint256));
+                inputToken = fillData.inputToken;
+                outputToken = fillData.outputToken;
+                inputTokenAmount = fillData.sellAmount;
+            } else if (selector == 0x21c184b6) {
+                // multiHopFill()
+                MultiHopFillData memory fillData;
+                (fillData, minOutputTokenAmount) =
+                    abi.decode(_data[4:], (MultiHopFillData, uint256));
+                require(fillData.tokens.length > 1, "Multihop token path too short");
+                inputToken = fillData.tokens[0];
+                outputToken = fillData.tokens[fillData.tokens.length - 1];
+                inputTokenAmount = fillData.sellAmount;
             } else {
                 revert("Unsupported 0xAPI function selector");
             }

--- a/test/protocol/integration/zeroExApiAdapter.spec.ts
+++ b/test/protocol/integration/zeroExApiAdapter.spec.ts
@@ -412,5 +412,218 @@ describe("ZeroExApiAdapter", () => {
         await expect(tx).to.be.revertedWith("Mismatched recipient");
       });
     });
+
+    describe("batchFill", () => {
+      it("validates data", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("batchFill", [
+          {
+              inputToken: sourceToken,
+              outputToken: destToken,
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const [target, value, _data] = await zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        expect(target).to.eq(zeroExMock.address);
+        expect(value).to.deep.eq(ZERO);
+        expect(_data).to.deep.eq(data);
+      });
+
+      it("rejects wrong input token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("batchFill", [
+          {
+              inputToken: otherToken,
+              outputToken: destToken,
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token");
+      });
+
+      it("rejects wrong output token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("batchFill", [
+          {
+              inputToken: sourceToken,
+              outputToken: otherToken,
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token");
+      });
+
+      it("rejects wrong input token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("batchFill", [
+          {
+              inputToken: sourceToken,
+              outputToken: destToken,
+              sellAmount: otherQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token quantity");
+      });
+
+      it("rejects wrong output token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("batchFill", [
+          {
+              inputToken: sourceToken,
+              outputToken: destToken,
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          otherQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token quantity");
+      });
+    });
+
+    describe("multiHopFill", () => {
+      it("validates data", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("multiHopFill", [
+          {
+              tokens: [sourceToken, destToken],
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const [target, value, _data] = await zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        expect(target).to.eq(zeroExMock.address);
+        expect(value).to.deep.eq(ZERO);
+        expect(_data).to.deep.eq(data);
+      });
+
+      it("rejects wrong input token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("multiHopFill", [
+          {
+              tokens: [otherToken, destToken],
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token");
+      });
+
+      it("rejects wrong output token", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("multiHopFill", [
+          {
+              tokens: [sourceToken, otherToken],
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token");
+      });
+
+      it("rejects wrong input token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("multiHopFill", [
+          {
+              tokens: [sourceToken, destToken],
+              sellAmount: otherQuantity,
+              calls: [],
+          },
+          minDestinationQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched input token quantity");
+      });
+
+      it("rejects wrong output token quantity", async () => {
+        const data = zeroExMock.interface.encodeFunctionData("multiHopFill", [
+          {
+              tokens: [sourceToken, destToken],
+              sellAmount: sourceQuantity,
+              calls: [],
+          },
+          otherQuantity,
+        ]);
+        const tx = zeroExApiAdapter.getTradeCalldata(
+          sourceToken,
+          destToken,
+          destination,
+          sourceQuantity,
+          minDestinationQuantity,
+          data,
+        );
+        await expect(tx).to.be.revertedWith("Mismatched output token quantity");
+      });
+    });
   });
 });


### PR DESCRIPTION
0x-API currently returns quotes that occasionally use two new functions: [`batchFill()`](https://github.com/0xProject/protocol/blob/development/contracts/zero-ex/contracts/src/features/interfaces/IMultiplexFeature.sol#L93) and [`multiHopFill()`](https://github.com/0xProject/protocol/blob/development/contracts/zero-ex/contracts/src/features/interfaces/IMultiplexFeature.sol#L110). The current adapter contract cannot detect/validate these new functions and will revert when trying to fill these quotes.

So here we are. :wave: 